### PR TITLE
Feature one

### DIFF
--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -2,6 +2,6 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   title: DS.attr('string'),
-  date: DS.attr('string'),
+  date: DS.attr('date'),
   notes: DS.attr('string'),
 });

--- a/app/models/reminder.js
+++ b/app/models/reminder.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  title: DS.attr('string'),
+  date: DS.attr('string'),
+  notes: DS.attr('string'),
+});

--- a/app/router.js
+++ b/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('reminders');
 });
 
 export default Router;

--- a/app/router.js
+++ b/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('reminders');
+  this.route('reminders', {path: '/'});
 });
 
 export default Router;

--- a/app/routes/reminders.js
+++ b/app/routes/reminders.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    return this.get('store').findAll('reminder');
+  }
+});

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h1>remEMBER</h1>
+
+{{outlet}}

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -1,0 +1,11 @@
+<h2> Reminder List </h2>
+
+<ul>
+  {{#each model as |reminder|}}
+    <li class="spec-reminder-item">
+      <div>Title: {{reminder.title}}</div>
+      <div>Date: {{reminder.date}}</div>
+      <div>Notes: {{reminder.notes}}</div>
+    </li>
+  {{/each}}
+</ul>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -3,7 +3,7 @@
 <ul>
   {{#each model as |reminder|}}
     <li class="spec-reminder-item">
-      <div>Title: {{reminder.title}}</div>
+      <h3>Title: {{reminder.title}}</h3>
       <div>Date: {{reminder.date}}</div>
       <div>Notes: {{reminder.notes}}</div>
     </li>

--- a/tests/unit/models/reminder-test.js
+++ b/tests/unit/models/reminder-test.js
@@ -1,0 +1,12 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('reminder', 'Unit | Model | reminder', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function(assert) {
+  let model = this.subject();
+  // let store = this.store();
+  assert.ok(!!model);
+});

--- a/tests/unit/routes/reminders-test.js
+++ b/tests/unit/routes/reminders-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:reminders', 'Unit | Route | reminders', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
@martensonbj @tman22 @stevekinney @nfosterky @kristenburgess25
## Purpose

Closes #1 . This issue shows all the reminders on the root page of the application. 

## Approach

It addresses the problem by adding a reminders route, model, and template.

### Learning

The problem was researched by referencing beard-beats-two and Ember.js guides.


#### Blog Posts

### Open Questions and Pre-Merge TODOs

-[X] Each reminder should have a class of .spec-reminder-item
-[X] Rnder the five reminders from the store
-[X] There is a failing test set up in tests/acceptance/reminder-list-item-test.js
-[X] When the user visits the root of the application, they should see a list of all of the reminders on the page 

### Test coverage 

Tests were prepopulated. All tests are passing except one that refers to another issue.

### Merge Dependencies and Related Work

Not Applicable

### Follow-up tasks

Next Issue TBD

### Screenshots

#### Before

#### After