### PR TITLE
Close Issue #18 - Remove Reminder

### DIFF
--- a/app/components/reminder-form.js
+++ b/app/components/reminder-form.js
@@ -5,8 +5,8 @@ export default Ember.Component.extend({
 
   actions: {
     saveReminder(model) {
-       model.date = model.date || new Date();
-       model.save();
+      model.date = model.date || new Date();
+      model.save();
       this.sendAction();
     }
   }

--- a/app/templates/components/reminder-form.hbs
+++ b/app/templates/components/reminder-form.hbs
@@ -8,7 +8,10 @@
     <label> Notes
       {{input class="new-reminder-input spec-note-input" value=model.notes}}
     </label>
-    <button {{action "saveReminder" model on='click'}} class="spec-save-edits-btn">   {{text}}</button>
-    <button {{action "rollbackChanges" model on='click'}} class="spec-revert-changes">
-      {{text-rollback}}</button>
+    <button {{action "saveReminder" model}} class="spec-save-edits-btn">
+      {{text}}
+    </button>
+    <button {{action "rollbackChanges" model}} class="spec-revert-changes">
+      {{text-rollback}}
+    </button>
   </form>

--- a/app/templates/reminders.hbs
+++ b/app/templates/reminders.hbs
@@ -4,10 +4,10 @@
     <h2> Reminder List </h2>
     <ul>
       {{#each model as |reminder|}}
-      <span class="unsaved">
-        {{if reminder.hasDirtyAttributes "Unsaved Changes to Reminder"}}
-      </span>
         <li >
+          <span class="unsaved">
+            {{if reminder.hasDirtyAttributes "Unsaved Changes to Reminder"}}
+          </span>
           {{#link-to 'reminders.reminder' reminder class='spec-reminder-item'}}
             {{reminder.title}}
           {{/link-to}}

--- a/app/templates/reminders/reminder.hbs
+++ b/app/templates/reminders/reminder.hbs
@@ -4,7 +4,6 @@
     {{#if model.notes}}
       <div class='spec-reminder-notes'> {{model.notes}}</div>
     {{/if}}
-    
 </section>
 
 {{outlet}}


### PR DESCRIPTION
@martensonbj @tman22 @stevekinney @nfosterky @ChelseaSkovgaard 
## Purpose

Closes #18. The purpose of this issue was to: add a button to the list of reminder and the individual reminder's page that allows the user to delete the reminder.

## Approach

The approach to this was to add actions to the reminder and reminders routes. These actions were passed on to buttons that were on the reminder and reminders templates. These used the Ember destroyRecord.

### Learning

We consulted colleagues and the Ember guides.

_Links to blog posts, patterns, libraries or add-ons used to solve this problem._

#### Blog Posts

### Open Questions and Pre-Merge TODOs

- [X] Add button to individual reminders list that allows the reminder to be deleted
-[X] Add button to individual reminder's page that allows the reminder to be deleted

### Test coverage 

We wrote an additional two acceptance tests to test the two delete buttons.

### Merge Dependencies and Related Work
Not Applicable

### Follow-up tasks

- Extentsions

### Screenshots

#### Before

#### After